### PR TITLE
#699 ContextMenu Enhancement

### DIFF
--- a/Src/MoneyFox.Windows/Views/UserControls/AccountListUserControl.xaml.cs
+++ b/Src/MoneyFox.Windows/Views/UserControls/AccountListUserControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 using MoneyFox.Shared.Model;
@@ -14,16 +15,16 @@ namespace MoneyFox.Windows.Views.UserControls {
 
         private void AccountList_Holding(object sender, HoldingRoutedEventArgs e) {
             var senderElement = sender as FrameworkElement;
-            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement);
+            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement) as MenuFlyout;
 
-            flyoutBase.ShowAt(senderElement);
+            flyoutBase.ShowAt(senderElement, e.GetPosition(senderElement));
         }
 
         private void AccountList_RightTapped(object sender, RightTappedRoutedEventArgs e) {
             var senderElement = sender as FrameworkElement;
-            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement);
+            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement) as MenuFlyout;
 
-            flyoutBase.ShowAt(senderElement);
+            flyoutBase.ShowAt(senderElement, e.GetPosition(senderElement));
         }
 
         private void Edit_OnClick(object sender, RoutedEventArgs e) {

--- a/Src/MoneyFox.Windows/Views/UserControls/CategoryListUserControl.xaml.cs
+++ b/Src/MoneyFox.Windows/Views/UserControls/CategoryListUserControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 using MoneyFox.Shared.Model;
@@ -14,16 +15,16 @@ namespace MoneyFox.Windows.Views.UserControls {
 
         private void CategoryListRightTapped(object sender, RightTappedRoutedEventArgs e) {
             var senderElement = sender as FrameworkElement;
-            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement);
+            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement) as MenuFlyout;
 
-            flyoutBase.ShowAt(senderElement);
+            flyoutBase.ShowAt(senderElement, e.GetPosition(senderElement));
         }
 
         private void CategoryListHolding(object sender, HoldingRoutedEventArgs e) {
             var senderElement = sender as FrameworkElement;
-            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement);
+            var flyoutBase = FlyoutBase.GetAttachedFlyout(senderElement) as MenuFlyout;
 
-            flyoutBase.ShowAt(senderElement);
+            flyoutBase.ShowAt(senderElement, e.GetPosition(senderElement));
         }
 
         private async void EditCategory(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
Updated menu's to now use MenuFlyout instead of just FlyoutBase. This allows ShowAt() to have a relative position (The mouse cursor location) to the actual senderElement.