### PR TITLE
issue #1092 fix, negative values display with negative sign 

### DIFF
--- a/Src/MoneyFox.Business.Tests/Converter/AmountFormatConverterTests.cs
+++ b/Src/MoneyFox.Business.Tests/Converter/AmountFormatConverterTests.cs
@@ -6,11 +6,12 @@ namespace MoneyFox.Business.Tests.Converter
 {
     public class AmountFormatConverterTests
     {
+
         [Fact]
-        public void Convert_FloatAmount_ValidString()
+        public void Convert_FloatAmmount_ValidString()
         {
             var amount = 123.45;
-            new AmountFormatConverter().Convert(amount, null, null, null).ShouldBe(amount.ToString("C"));
+            new AmountFormatConverter().Convert(amount, null, null, System.Globalization.CultureInfo.CurrentCulture).ShouldBe(amount.ToString("C"));
         }
 
         [Fact]

--- a/Src/MoneyFox.Business/Converter/AmountFormatConverter.cs
+++ b/Src/MoneyFox.Business/Converter/AmountFormatConverter.cs
@@ -9,7 +9,13 @@ namespace MoneyFox.Business.Converter
     /// </summary>
     public class AmountFormatConverter : IMvxValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => $"{value:C2}";
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            double currencyValue = (double)value;
+            NumberFormatInfo number = culture.NumberFormat;
+            number.CurrencyNegativePattern = 1;                     // formats negative values to have the "-" symbol in front of its culture
+            return currencyValue.ToString("C", number);
+        }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => value;
     }

--- a/Src/MoneyFox.Business/Converter/AmountFormatConverter.cs
+++ b/Src/MoneyFox.Business/Converter/AmountFormatConverter.cs
@@ -12,9 +12,8 @@ namespace MoneyFox.Business.Converter
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             double currencyValue = (double)value;
-            NumberFormatInfo number = culture.NumberFormat;
-            number.CurrencyNegativePattern = 1;                     // formats negative values to have the "-" symbol in front of its culture
-            return currencyValue.ToString("C", number);
+            culture.NumberFormat.CurrencyNegativePattern = 1;  // formats negative values to have the "-" symbol in front of its culture
+            return currencyValue.ToString("C");
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => value;


### PR DESCRIPTION
Previously a negative value of an account displayed with parentheses around the value, i.e. -$99.00 => ($99.00). This was the default CurrencyNegativePattern used to format the string that result from convert. I created a new NumberFormatInfo object using the previously or default defined culture "$", changed its CurrencyNegativePattern to have the negative symbol in the front, and formatted the value accordingly.
