### PR TITLE
bugFix for issue #1052, 

### DIFF
--- a/Src/MoneyFox.Business/ViewModels/ModifyPaymentViewModel.cs
+++ b/Src/MoneyFox.Business/ViewModels/ModifyPaymentViewModel.cs
@@ -368,6 +368,8 @@ namespace MoneyFox.Business.ViewModels
 
             // Make sure that the old amount is removed to not count the amount twice.
             RemoveOldAmount();
+            if (amount < 0)
+                amount *= -1;
             SelectedPayment.Amount = amount;
 
             //Create a recurring PaymentViewModel based on the PaymentViewModel or update an existing


### PR DESCRIPTION
if the user adds a value with the negative operator when creating a new expense or income, the program will handle the value without the use of the operator.