### PR TITLE
Fixed Link to Contributions Page

### DIFF
--- a/Src/MoneyFox.Business/ViewModels/AboutViewModel.cs
+++ b/Src/MoneyFox.Business/ViewModels/AboutViewModel.cs
@@ -129,7 +129,7 @@ namespace MoneyFox.Business.ViewModels
 
         private void GoToContributionPage()
         {
-            webBrowserTask.ShowWebPage(Constants.ICONDESIGNER_TWITTER_URL);
+            webBrowserTask.ShowWebPage(Constants.GITHUB_CONTRIBUTION_URL);
         }
     }
 }


### PR DESCRIPTION
Fixed the link going to the GitHub Contributions page. This fixes issue #1164 