### PR TITLE
Ensure consistent page transitions for all pages.

### DIFF
--- a/Src/MoneyFox.Uwp/Views/AddAccountView.xaml
+++ b/Src/MoneyFox.Uwp/Views/AddAccountView.xaml
@@ -10,7 +10,8 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />

--- a/Src/MoneyFox.Uwp/Views/AddCategoryView.xaml
+++ b/Src/MoneyFox.Uwp/Views/AddCategoryView.xaml
@@ -9,7 +9,8 @@
     SizeChanged="AddCategoryView_OnSizeChanged"    
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
@@ -20,7 +21,7 @@
                    Text="{Binding Title}"
                    Style="{StaticResource UwpPageTitleStyle}" />
 
-        <Grid Grid.Row="1" x:Name="ContentGrid" EntranceNavigationTransitionInfo.IsTargetElement="True" />
+        <Grid Grid.Row="1" x:Name="ContentGrid" />
 
         <CommandBar x:Name="BottomCommandBar"
                     Grid.Row="2"

--- a/Src/MoneyFox.Uwp/Views/AddPaymentView.xaml
+++ b/Src/MoneyFox.Uwp/Views/AddPaymentView.xaml
@@ -9,7 +9,8 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />

--- a/Src/MoneyFox.Uwp/Views/CategoryListView.xaml
+++ b/Src/MoneyFox.Uwp/Views/CategoryListView.xaml
@@ -12,8 +12,8 @@
         <designTime:DesignTimeCategoryListViewModel />
     </d:MvxWindowsPage.DataContext>
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}"
-          EntranceNavigationTransitionInfo.IsTargetElement="True">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}" >
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/Src/MoneyFox.Uwp/Views/EditAccountView.xaml
+++ b/Src/MoneyFox.Uwp/Views/EditAccountView.xaml
@@ -10,7 +10,8 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+        Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />

--- a/Src/MoneyFox.Uwp/Views/EditCategoryView.xaml
+++ b/Src/MoneyFox.Uwp/Views/EditCategoryView.xaml
@@ -11,7 +11,8 @@
     SizeChanged="EditCategoryView_OnSizeChanged"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
@@ -22,7 +23,7 @@
                    Text="{Binding Title}"
                    Style="{StaticResource UwpPageTitleStyle}" />
 
-        <Grid Grid.Row="1" x:Name="ContentGrid" EntranceNavigationTransitionInfo.IsTargetElement="True" />
+        <Grid Grid.Row="1" x:Name="ContentGrid" />
 
         <CommandBar x:Name="BottomCommandBar"
                     Grid.Row="2"

--- a/Src/MoneyFox.Uwp/Views/EditPaymentView.xaml
+++ b/Src/MoneyFox.Uwp/Views/EditPaymentView.xaml
@@ -9,7 +9,8 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />

--- a/Src/MoneyFox.Uwp/Views/LoginView.xaml
+++ b/Src/MoneyFox.Uwp/Views/LoginView.xaml
@@ -6,7 +6,7 @@
                       xmlns:views1="using:MvvmCross.Platforms.Uap.Views"
                       mc:Ignorable="d">
 
-    <Grid>
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="65*" />
             <RowDefinition Height="37*" />

--- a/Src/MoneyFox.Uwp/Views/PaymentListView.xaml
+++ b/Src/MoneyFox.Uwp/Views/PaymentListView.xaml
@@ -38,7 +38,8 @@
         </Flyout>
     </Page.Resources>
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
@@ -50,8 +51,7 @@
                    Style="{StaticResource UwpPageTitleStyle}" />
 
         <Grid Grid.Row="1"
-              Margin="{StaticResource NegativeMediumLeftRightWithTopMargin}"
-              EntranceNavigationTransitionInfo.IsTargetElement="True">
+              Margin="{StaticResource NegativeMediumLeftRightWithTopMargin}">
             <userControls:PaymentListUserControl />
         </Grid>
 

--- a/Src/MoneyFox.Uwp/Views/SelectCategoryListView.xaml
+++ b/Src/MoneyFox.Uwp/Views/SelectCategoryListView.xaml
@@ -26,7 +26,8 @@
         </core:EventTriggerBehavior>
     </interactivity:Interaction.Behaviors>
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/Src/MoneyFox.Uwp/Views/SettingsView.xaml
+++ b/Src/MoneyFox.Uwp/Views/SettingsView.xaml
@@ -29,7 +29,7 @@
         </core:EventTriggerBehavior>
     </interactivity:Interaction.Behaviors>
 
-    <Grid>
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True">
         <Pivot>
             <!--  Settings  -->
             <PivotItem>

--- a/Src/MoneyFox.Uwp/Views/StatisticCashFlowView.xaml
+++ b/Src/MoneyFox.Uwp/Views/StatisticCashFlowView.xaml
@@ -12,7 +12,8 @@
         <designTime1:DesignTimeStatisticCashFlowViewModel />
     </d:MvxWindowsPage.DataContext>
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="20" />

--- a/Src/MoneyFox.Uwp/Views/StatisticCategorySpreadingView.xaml
+++ b/Src/MoneyFox.Uwp/Views/StatisticCategorySpreadingView.xaml
@@ -13,7 +13,8 @@
         <designTime:DesignTimeStatisticCategorySpreadingViewModel />
     </d:MvxWindowsPage.DataContext>
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/Src/MoneyFox.Uwp/Views/StatisticCategorySummaryView.xaml
+++ b/Src/MoneyFox.Uwp/Views/StatisticCategorySummaryView.xaml
@@ -45,7 +45,7 @@
         </DataTemplate>
     </Page.Resources>
 
-    <Grid>
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
@@ -71,7 +71,6 @@
                        Text="{Binding Title}" />
 
             <ScrollViewer Grid.Row="1"
-                          EntranceNavigationTransitionInfo.IsTargetElement="True"
                           VerticalScrollBarVisibility="Auto"
                           Margin="{StaticResource NegativeMediumLeftRightWithTopMargin}">
                 <ListView Background="Transparent"

--- a/Src/MoneyFox.Uwp/Views/StatisticSelectorView.xaml
+++ b/Src/MoneyFox.Uwp/Views/StatisticSelectorView.xaml
@@ -35,7 +35,8 @@
         </DataTemplate>
     </Page.Resources>
 
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True"
+          Margin="{StaticResource MediumLeftRightMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
@@ -47,7 +48,6 @@
         <ScrollViewer Grid.Row="1"
                       Margin="{StaticResource NegativeLargeLeftRightMargin}"
                       HorizontalAlignment="Stretch"
-                      EntranceNavigationTransitionInfo.IsTargetElement="True"
                       VerticalScrollBarVisibility="Disabled">
 
             <ListView ItemTemplate="{StaticResource StatistcTypeTemplate}"

--- a/Src/MoneyFox.Uwp/Views/UserControls/AboutUserControl.xaml
+++ b/Src/MoneyFox.Uwp/Views/UserControls/AboutUserControl.xaml
@@ -12,7 +12,6 @@
 
     <Grid>
         <ScrollViewer HorizontalAlignment="Center"
-                      EntranceNavigationTransitionInfo.IsTargetElement="True"
                       VerticalScrollBarVisibility="Auto">
             <StackPanel>
 

--- a/Src/MoneyFox.Uwp/Views/UserControls/BalanceUserControl.xaml
+++ b/Src/MoneyFox.Uwp/Views/UserControls/BalanceUserControl.xaml
@@ -12,8 +12,7 @@
         <converter:NativeAmountFormatConverter x:Key="AmountFormatConverter" />
     </UserControl.Resources>
 
-    <StackPanel EntranceNavigationTransitionInfo.IsTargetElement="True"
-                Orientation="Horizontal">
+    <StackPanel Orientation="Horizontal">
         <TextBlock x:Uid="TotalLabel"
                    Margin="0,0,5,10"
                    Style="{StaticResource DeemphasizedBodyTextBlockStyle}"

--- a/Src/MoneyFox.Uwp/Views/UserControls/CategoryListUserControl.xaml
+++ b/Src/MoneyFox.Uwp/Views/UserControls/CategoryListUserControl.xaml
@@ -71,7 +71,7 @@
                               Source="{Binding CategoryList}" />
     </UserControl.Resources>
 
-    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True" >
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="60" />
             <RowDefinition Height="240*" />

--- a/Src/MoneyFox.Uwp/Views/UserControls/ModifyAccountUserControl.xaml
+++ b/Src/MoneyFox.Uwp/Views/UserControls/ModifyAccountUserControl.xaml
@@ -10,7 +10,7 @@
 
     <ScrollViewer HorizontalScrollMode="Auto"
                   VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="12,0,12,0" EntranceNavigationTransitionInfo.IsTargetElement="True">
+        <StackPanel Margin="12,0,12,0">
             <TextBox x:Uid="Name"
                          Margin="{StaticResource SmallTitleContentMargin}"
                          VerticalAlignment="Top"

--- a/Src/MoneyFox.Uwp/Views/UserControls/ModifyPaymentUserControl.xaml
+++ b/Src/MoneyFox.Uwp/Views/UserControls/ModifyPaymentUserControl.xaml
@@ -36,7 +36,7 @@
         </DataTemplate>
     </UserControl.Resources>
 
-    <Grid EntranceNavigationTransitionInfo.IsTargetElement="True">
+    <Grid>
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel>
                 <ComboBox Margin="{StaticResource SmallTitleContentMargin}"


### PR DESCRIPTION
Removed EntranceNavigationTransitionInfo.IsTargetElement="True" from all user controls and ensured it was added to all root elements in all pages to ensure consistent page transitions. 

The transition animation does not need to be in place on the user controls as it's effect will be applied further up the visual tree, so has been removed from all user controls which will always be displayed inside a page element.

Issue: #1497

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Current behavior is described in issue #1497

## What is the new behavior?
All pages show a page entry transition animation consistent with Fluent Design guidelines.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code on Windows
- [ ] Tested code on Android
- [ ] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes

Fix not applicable to Android or iOS platforms. No tests are applicable for this type of change.

## Other information
