### PR TITLE
Fix Account Deletion - Remove hard-coded account id

### DIFF
--- a/Src/MoneyFox.ServiceLayer/ViewModels/AccountListViewModel.cs
+++ b/Src/MoneyFox.ServiceLayer/ViewModels/AccountListViewModel.cs
@@ -139,7 +139,7 @@ namespace MoneyFox.ServiceLayer.ViewModels
             if (await dialogService.ShowConfirmMessage(Strings.DeleteTitle, Strings.DeleteAccountConfirmationMessage)
                 .ConfigureAwait(true))
             {
-                await crudService.DeleteAndSaveAsync<Account>(5)
+                await crudService.DeleteAndSaveAsync<Account>(accountToDelete.Id)
                     .ConfigureAwait(true);
 
                 Accounts.Clear();


### PR DESCRIPTION
Remove hard-coded account id, replacing it with the accountToDelete.Id so that the actual account can be deleted successfully.

Issue: #1526

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Accounts can't be deleted.

## What is the new behavior?
An Account can be deleted.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [X] Tested code on Windows
- [X] Tested code on Android
- [X] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Appium UI Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes

## Other information