### PR TITLE
Added support for back and forward navigation via mouse buttons

### DIFF
--- a/Src/MoneyFox.Uwp/Services/NavigationService.cs
+++ b/Src/MoneyFox.Uwp/Services/NavigationService.cs
@@ -55,9 +55,14 @@ namespace MoneyFox.Uwp.Services
             return false;
         }
 
-        public void GoForward()
+        public bool GoForward()
         {
-            Frame.GoForward();
+            if (CanGoForward)
+            {
+                Frame.GoForward();
+                return true;
+            }
+            return false;
         }
 
         public bool Navigate(string pageKey, object parameter = null, NavigationTransitionInfo infoOverride = null)

--- a/Src/MoneyFox.Uwp/WindowsShellViewModel.cs
+++ b/Src/MoneyFox.Uwp/WindowsShellViewModel.cs
@@ -16,6 +16,8 @@ using MoneyFox.Uwp.Services;
 using MoneyFox.Uwp.ViewModels.Settings;
 using NLog;
 using WinUI = Microsoft.UI.Xaml.Controls;
+using Windows.UI.Core;
+using Windows.UI.Input;
 
 namespace MoneyFox.Uwp
 {
@@ -64,6 +66,24 @@ namespace MoneyFox.Uwp
             NavigationService.NavigationFailed += Frame_NavigationFailed;
             NavigationService.Navigated += Frame_Navigated;
             this.navigationView.BackRequested += OnBackRequested;
+
+            Windows.UI.Core.CoreWindow.GetForCurrentThread().PointerPressed += On_PointerPressed;
+        }
+        private void On_PointerPressed(CoreWindow sender, PointerEventArgs e)
+        {
+            bool isXButton1Pressed = e.CurrentPoint.Properties.PointerUpdateKind == PointerUpdateKind.XButton1Pressed;
+
+            if (isXButton1Pressed)
+            {
+                e.Handled = WindowsShellViewModel.NavigationService.GoBack();
+            }
+
+            bool isXButton2Pressed = e.CurrentPoint.Properties.PointerUpdateKind == PointerUpdateKind.XButton2Pressed;
+
+            if (isXButton2Pressed)
+            {
+                e.Handled = WindowsShellViewModel.NavigationService.GoForward();
+            }
         }
 
         private async Task OnLoadedAsync()


### PR DESCRIPTION
Issue: #
https://github.com/MoneyFox/MoneyFox/issues/1390

## PR Type
What kind of change does this PR introduce?
Feature


## What is the current behavior?
Nothing happens when using mouse back/forward buttons


## What is the new behavior?
Mouse back/forward buttons will navigate back and forward in any window/UI element

## PR Checklist

Please check if your PR fulfills the following requirements:

Windows only feature.
Hard to test without physically pressing mouse buttons

- [X] Tested code on Windows
- [ ] Tested code on Android
- [ ] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The code:
Windows.UI.Core.CoreWindow.GetForCurrentThread().PointerPressed += On_PointerPressed;
Feels a little out of place.
Let me know if you have any other solution/idea.
The normal KeyboardAccelerators does not work for mouse buttons.

rootFrame.PointerPressed += On_PointerPressed;
Only works when mouse is on UI elements.
