### PR TITLE
Require category note

### DIFF
--- a/Src/MoneyFox.Application/Resources/Strings.Designer.cs
+++ b/Src/MoneyFox.Application/Resources/Strings.Designer.cs
@@ -925,7 +925,7 @@ namespace MoneyFox.Application.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expense {1} / Income: {0}.
+        ///   Looks up a localized string similar to Expense: {0} / Income: {1}.
         /// </summary>
         public static string ExpenseAndIncomeTemplate {
             get {
@@ -1444,6 +1444,15 @@ namespace MoneyFox.Application.Resources {
         public static string NoteLabel {
             get {
                 return ResourceManager.GetString("NoteLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please insert a note..
+        /// </summary>
+        public static string NoteRequiredMessage {
+            get {
+                return ResourceManager.GetString("NoteRequiredMessage", resourceCulture);
             }
         }
         

--- a/Src/MoneyFox.Application/Resources/Strings.resx
+++ b/Src/MoneyFox.Application/Resources/Strings.resx
@@ -735,4 +735,7 @@ To get there go to the account list and select the respective account.</value>
   <data name="LoggedInMessage" xml:space="preserve">
     <value>Loggedin successfully.</value>
   </data>
+  <data name="NoteRequiredMessage" xml:space="preserve">
+    <value>Please insert a note.</value>
+  </data>
 </root>

--- a/Src/MoneyFox.Uwp/ViewModels/AddCategoryViewModel.cs
+++ b/Src/MoneyFox.Uwp/ViewModels/AddCategoryViewModel.cs
@@ -41,6 +41,12 @@ namespace MoneyFox.Uwp.ViewModels
                 return;
             }
 
+            if(string.IsNullOrEmpty(SelectedCategory.Note))
+            {
+                await DialogService.ShowMessageAsync(Strings.MandatoryFieldEmptyTitle, Strings.NoteRequiredMessage);
+                return;
+            }
+
             await mediator.Send(new CreateCategoryCommand(SelectedCategory.Name, SelectedCategory.Note));
         }
     }

--- a/Src/MoneyFox/ViewModels/Categories/ModifyCategoryViewModel.cs
+++ b/Src/MoneyFox/ViewModels/Categories/ModifyCategoryViewModel.cs
@@ -49,6 +49,12 @@ namespace MoneyFox.ViewModels.Categories
                 return;
             }
 
+            if(string.IsNullOrEmpty(SelectedCategory.Note))
+            {
+                await dialogService.ShowMessageAsync(Strings.MandatoryFieldEmptyTitle, Strings.NoteRequiredMessage);
+                return;
+            }
+
             if(await mediator.Send(new GetIfCategoryWithNameExistsQuery(SelectedCategory.Name)))
             {
                 await dialogService.ShowMessageAsync(Strings.DuplicatedNameTitle, Strings.DuplicateCategoryMessage);


### PR DESCRIPTION
Issue: #1607

## PR Type 
Add require note to create category


## What is the current behavior?
Categories can be created without a note


## What is the new behavior?
Shows a dialog when the user tries to create a category without note and doesn't save the category

## PR Checklist 

Please check if your PR fulfills the following requirements:

<!-- If the code was not tested on all plattforms, please describe why. -->

- [x] Tested code on Windows
- [x] Tested code on Android
- [ ] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
