### PR TITLE
CategorySpreadingNumber is now presistend after closing the App

### DIFF
--- a/Src/MoneyFox.Uwp/Services/CategoryNumberSpreadingService.cs
+++ b/Src/MoneyFox.Uwp/Services/CategoryNumberSpreadingService.cs
@@ -1,0 +1,38 @@
+﻿using MoneyFox.Uwp.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+
+namespace MoneyFox.Uwp.Services
+{
+    public static class CategoryNumberSpreadingService
+    {
+        private const string SettingsKey = "AppCategoryNumberSpreading";
+
+        public static int CategoryNumberSpreading { get; set; } = 6;
+
+        public static void Initialize() => CategoryNumberSpreading = LoadCategoryNumberSpreadingFromSettings();
+
+        public static int LoadCategoryNumberSpreadingFromSettings()
+        {
+            string categoryNumberSettingValue = ApplicationData.Current.LocalSettings.Read<string>(SettingsKey);
+
+            int categoryNumber = 0;
+
+            if(!string.IsNullOrEmpty(categoryNumberSettingValue))
+                categoryNumber = int.Parse(categoryNumberSettingValue);
+            else
+            {
+                SaveCategoryNumberSpreadingInSettings(CategoryNumberSpreading);
+                categoryNumber = CategoryNumberSpreading;
+            }
+
+            return categoryNumber;
+        }
+
+        public static void SaveCategoryNumberSpreadingInSettings(int categoryNumber) => ApplicationData.Current.LocalSettings.SaveString(SettingsKey, categoryNumber.ToString());
+    }
+}

--- a/Src/MoneyFox.Uwp/ViewModels/Statistic/StatisticCategorySpreadingViewModel.cs
+++ b/Src/MoneyFox.Uwp/ViewModels/Statistic/StatisticCategorySpreadingViewModel.cs
@@ -4,6 +4,7 @@ using MoneyFox.Application.Statistics;
 using MoneyFox.Application.Statistics.Queries;
 using MoneyFox.Domain;
 using MoneyFox.Ui.Shared.ViewModels.Statistics;
+using MoneyFox.Uwp.Services;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -18,7 +19,7 @@ namespace MoneyFox.Uwp.ViewModels.Statistic
     public class StatisticCategorySpreadingViewModel : StatisticViewModel, IStatisticCategorySpreadingViewModel
     {
         private ObservableCollection<StatisticEntry> statisticItems = new ObservableCollection<StatisticEntry>();
-        private int numberOfCategoriesToShow = 6;
+        private int numberOfCategoriesToShow = CategoryNumberSpreadingService.LoadCategoryNumberSpreadingFromSettings();
         private PaymentType selectedPaymentType;
 
         public StatisticCategorySpreadingViewModel(IMediator mediator) : base(mediator)
@@ -71,6 +72,7 @@ namespace MoneyFox.Uwp.ViewModels.Statistic
                     return;
                 }
                 numberOfCategoriesToShow = value;
+                CategoryNumberSpreadingService.SaveCategoryNumberSpreadingInSettings(value);
                 RaisePropertyChanged();
             }
         }


### PR DESCRIPTION
Issue: #1968

## PR Type
What kind of change does this PR introduce?
Feature:
CategorySpreadingNumber is now saved in Settings.


## What is the current behavior?
CategorySpreadingNumber was not persistend.


## What is the new behavior?
CategorySpreadingNumber is now persistend.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code on Windows
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes


## Other information
Hey,

I'm kinda new to OpenSource projects. If I did something wrong or forgot something I would be glad if you told me what I did wrong. Would be great if I have the opportunity to fix it then.