### PR TITLE
Fix for issue #2210 crash when clicking links in "About" section

### DIFF
--- a/Src/MoneyFox.Win.Infrastructure/Adapters/BrowserAdapter.cs
+++ b/Src/MoneyFox.Win.Infrastructure/Adapters/BrowserAdapter.cs
@@ -9,7 +9,11 @@ namespace MoneyFox.Win.Infrastructure.Adapters
     {
         public async Task OpenWebsiteAsync(Uri uri)
         {
-            Process.Start(uri.ToString());
+            Process.Start(new ProcessStartInfo(uri.ToString())
+            {
+                UseShellExecute = true
+            });
+
             await Task.CompletedTask;
         }
     }


### PR DESCRIPTION
Issue: #2210 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
- Application crashes if the user clicks on any links within the "About" section of the settings, and links do not open in the browser.

## What is the new behavior?
- The links now open successfully in the user's browser, and the application does not crash.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code on Windows
- [ ] Tested code on Android
- [ ] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes

## Other information
- All tests pass.
