### PR TITLE
Corrected Modification Date and Creation Date bindings in Payment List on Windows

### DIFF
--- a/Src/MoneyFox.Win/MoneyFox.Win/Pages/Payments/PaymentListPage.xaml
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Pages/Payments/PaymentListPage.xaml
@@ -134,9 +134,9 @@
                                                  Binding="{Binding RecurringPayment.Recurrence, Converter={StaticResource RecurrenceTypeConverter}}" />
 
                     <controls:DataGridTextColumn Header="{x:Bind resources:Strings.ModificationDateHeader}"
-                                                 Binding="{Binding ModificationDate, Converter={StaticResource DateTimeToStringConverter}}" />
+                                                 Binding="{Binding LastModified, Converter={StaticResource DateTimeToStringConverter}}" />
                     <controls:DataGridTextColumn Header="{x:Bind resources:Strings.CreationDateHeader}"
-                                                 Binding="{Binding CreationTime, Converter={StaticResource DateTimeToStringConverter}}" />
+                                                 Binding="{Binding Created, Converter={StaticResource DateTimeToStringConverter}}" />
                 </controls:DataGrid.Columns>
 
             </controls:DataGrid>


### PR DESCRIPTION
Issue: #2262 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Modified Date and Creation Date columns are empty in the payment list for accounts.


## What is the new behavior?
The Modified Date and Creation Date columns now display the appropriate dates in the payment list for accounts.


## PR Checklist

Please check if your PR fulfills the following requirements:

<!-- If the code was not tested on all platforms, please describe why. -->

- [x] Tested code on Windows
- [x] Tested code on Android
- [ ] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

Issue was isolated to the Windows form.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
