### PR TITLE
Alternate text color for negative account balances.

### DIFF
--- a/Src/MoneyFox.Win/MoneyFox.Win/Converter/BalanceColorConverter.cs
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Converter/BalanceColorConverter.cs
@@ -1,0 +1,17 @@
+namespace MoneyFox.Win.Converter;
+
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+public class BalanceColorConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object? parameter, string language)
+    {
+        string styleKey = (value is decimal d && d < 0) ? "NegativeBalanceColorBrush" : "AppForegroundPrimaryBrush";
+        return Application.Current.Resources.TryGetValue(styleKey, out var styleValue) ? styleValue : throw new InvalidOperationException($"Failed to find the style '{styleKey}' in the resource dictionary.");
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}

--- a/Src/MoneyFox.Win/MoneyFox.Win/Pages/Accounts/AccountListPage.xaml
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Pages/Accounts/AccountListPage.xaml
@@ -29,6 +29,7 @@
     <Page.Resources>
         <converter:AmountFormatConverter x:Key="AmountFormatConverter" />
         <converter:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converter:BalanceColorConverter x:Key="BalanceColorConverter" />
 
         <DataTemplate x:Key="AccountItemTemplate" x:DataType="accounts:AccountViewModel">
             <Grid Height="100" Width="250"
@@ -59,13 +60,14 @@
                     VerticalAlignment="Center"
                     Style="{ThemeResource CustomSubtitleTextBlockStyle}"
                     Text="{x:Bind CurrentBalance, Converter={StaticResource AmountFormatConverter}}"
-                    TextAlignment="Center" />
+                    TextAlignment="Center"
+                    Foreground="{x:Bind CurrentBalance, Converter={StaticResource BalanceColorConverter}}"/>
 
                 <StackPanel Orientation="Horizontal"
                             VerticalAlignment="Bottom"
                             HorizontalAlignment="Right">
                     <TextBlock Text="{x:Bind resources:Strings.EndOfMonthLabel}" Margin="0,0,6,0" />
-                    <TextBlock
+                    <TextBlock Foreground="{x:Bind EndOfMonthBalance, Converter={StaticResource BalanceColorConverter}}"
                         Text="{x:Bind EndOfMonthBalance, Converter={StaticResource AmountFormatConverter}}" />
                 </StackPanel>
             </Grid>

--- a/Src/MoneyFox.Win/MoneyFox.Win/Pages/UserControls/BalanceControl.xaml
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Pages/UserControls/BalanceControl.xaml
@@ -12,6 +12,7 @@
 
     <UserControl.Resources>
         <converter:AmountFormatConverter x:Key="AmountFormatConverter" />
+        <converter:BalanceColorConverter x:Key="BalanceColorConverter" />
     </UserControl.Resources>
 
     <Grid>
@@ -27,7 +28,8 @@
                 <TextBlock
                     Margin="0,0,5,0"
                     Style="{ThemeResource DeemphasizedBodyTextBlockStyle}"
-                    Text="{Binding TotalBalance, Mode=TwoWay, Converter={StaticResource AmountFormatConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                    Text="{Binding TotalBalance, Mode=TwoWay, Converter={StaticResource AmountFormatConverter}, UpdateSourceTrigger=PropertyChanged}"
+                    Foreground="{Binding TotalBalance, Converter={StaticResource BalanceColorConverter}}" />
             </StackPanel>
 
             <StackPanel
@@ -42,7 +44,8 @@
                 <TextBlock
                     Margin="0,0,5,0"
                     Style="{ThemeResource DeemphasizedBodyTextBlockStyle}"
-                    Text="{Binding EndOfMonthBalance, Mode=TwoWay, Converter={StaticResource AmountFormatConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                    Text="{Binding EndOfMonthBalance, Mode=TwoWay, Converter={StaticResource AmountFormatConverter}, UpdateSourceTrigger=PropertyChanged}"
+                    Foreground="{Binding EndOfMonthBalance, Converter={StaticResource BalanceColorConverter}}" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/Src/MoneyFox.Win/MoneyFox.Win/Style/AppStyles.xaml
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Style/AppStyles.xaml
@@ -53,4 +53,5 @@
         Color="{ThemeResource SystemAccentColor}" />
     <SolidColorBrush x:Key="SystemControlHyperlinkTextBrush" Color="{ThemeResource SystemAccentColor}" />
     <SolidColorBrush x:Key="JumpListDefaultEnabledBackground" Color="{ThemeResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="NegativeBalanceColorBrush" Color="{StaticResource WarningColor}" />
 </ResourceDictionary>

--- a/Src/MoneyFox/Common/Styles/DefaultTheme.xaml
+++ b/Src/MoneyFox/Common/Styles/DefaultTheme.xaml
@@ -161,6 +161,14 @@
         <Setter Property="TextColor" Value="{DynamicResource ThemePrimary}" />
     </Style>
 
+    <Style x:Key="BalanceLabelPositive" TargetType="Label">
+        <Setter Property="TextColor"
+                Value="{AppThemeBinding Dark={StaticResource TextPrimaryColor_Dark}, Light={StaticResource TextPrimaryColor_Light}}" />
+    </Style>
+
+    <Style x:Key="BalanceLabelNegative" TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource Warning}" />
+    </Style>
 
     <!-- Buttons -->
     <Style TargetType="Button">

--- a/Src/MoneyFox/Converter/BalanceColorConverter.cs
+++ b/Src/MoneyFox/Converter/BalanceColorConverter.cs
@@ -1,0 +1,19 @@
+namespace MoneyFox.Converter
+{
+
+    using System;
+    using System.Globalization;
+    using Xamarin.Forms;
+
+    public class BalanceColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string styleKey = (value is decimal d && d < 0) ? "BalanceLabelNegative" : "BalanceLabelPositive";
+            return Application.Current.Resources.TryGetValue(styleKey, out var styleValue) ? styleValue : throw new InvalidOperationException($"Failed to find the style '{styleKey}' in the resource dictionary.");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+            throw new NotSupportedException();
+    }
+}

--- a/Src/MoneyFox/Views/Accounts/AccountListPage.xaml
+++ b/Src/MoneyFox/Views/Accounts/AccountListPage.xaml
@@ -16,6 +16,7 @@
 
     <ContentPage.Resources>
         <converter:AmountFormatConverter x:Key="AmountFormatConverter" />
+        <converter:BalanceColorConverter x:Key="BalanceColorConverter" />
     </ContentPage.Resources>
 
     <ContentPage.Content>
@@ -93,6 +94,7 @@
                                             FontFamily="Product"
                                             FontSize="20"
                                             HorizontalTextAlignment="Center"
+                                            Style="{Binding CurrentBalance, Converter={StaticResource BalanceColorConverter}}"
                                             Text="{Binding CurrentBalance, Converter={StaticResource AmountFormatConverter}}"
                                             VerticalTextAlignment="Center" />
 
@@ -112,6 +114,7 @@
                                                 FontFamily="Product"
                                                 FontSize="15"
                                                 HorizontalTextAlignment="End"
+                                                Style="{Binding EndOfMonthBalance, Converter={StaticResource BalanceColorConverter}}"
                                                 Text="{Binding EndOfMonthBalance, Converter={StaticResource AmountFormatConverter}}"
                                                 VerticalTextAlignment="End" />
                                         </StackLayout>

--- a/Src/MoneyFox/Views/Dashboard/DashboardPage.xaml
+++ b/Src/MoneyFox/Views/Dashboard/DashboardPage.xaml
@@ -16,6 +16,7 @@
 
     <ContentPage.Resources>
         <converter:AmountFormatConverter x:Key="AmountFormatConverter" />
+        <converter:BalanceColorConverter x:Key="BalanceColorConverter" />
     </ContentPage.Resources>
 
     <Shell.TitleView>
@@ -76,6 +77,7 @@
                             FontFamily="Product"
                             FontSize="22"
                             HorizontalTextAlignment="Center"
+                            Style="{Binding Assets, Converter={StaticResource BalanceColorConverter}}"
                             Text="{Binding Assets, Converter={StaticResource AmountFormatConverter}}"
                             VerticalTextAlignment="Center" />
 
@@ -95,6 +97,7 @@
                                 FontFamily="Product"
                                 FontSize="15"
                                 HorizontalTextAlignment="End"
+                                Style="{Binding EndOfMonthBalance, Converter={StaticResource BalanceColorConverter}}"
                                 Text="{Binding EndOfMonthBalance, Converter={StaticResource AmountFormatConverter}}"
                                 VerticalTextAlignment="End" />
                         </StackLayout>
@@ -145,6 +148,7 @@
                                                 FontFamily="Product"
                                                 FontSize="20"
                                                 HorizontalTextAlignment="Center"
+                                                Style="{Binding CurrentBalance, Converter={StaticResource BalanceColorConverter}}"
                                                 Text="{Binding CurrentBalance, Converter={StaticResource AmountFormatConverter}}"
                                                 VerticalTextAlignment="Center" />
 
@@ -164,6 +168,7 @@
                                                     FontFamily="Product"
                                                     FontSize="10"
                                                     HorizontalTextAlignment="End"
+                                                    Style="{Binding EndOfMonthBalance, Converter={StaticResource BalanceColorConverter}}"
                                                     Text="{Binding EndOfMonthBalance, Converter={StaticResource AmountFormatConverter}}"
                                                     VerticalTextAlignment="End" />
                                             </StackLayout>


### PR DESCRIPTION
Issue: #1950 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Negative account balance display fields have the same styling as positive/zero account balances.

## What is the new behavior?
Negative account balance display fields use an alternate (red) font color to highlight a problem to the end-user.


## PR Checklist

Please check if your PR fulfills the following requirements:

<!-- If the code was not tested on all plattforms, please describe why. -->

- [x] Tested code on Windows
- [x] Tested code on Android
- [x] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
