### PR TITLE
Fixed NullReferenceException when recurrence is disabled for existing…

### DIFF
--- a/Src/MoneyFox.Core/Commands/Payments/UpdatePayment/UpdatePaymentCommand.cs
+++ b/Src/MoneyFox.Core/Commands/Payments/UpdatePayment/UpdatePaymentCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace MoneyFox.Core.Commands.Payments.UpdatePayment
+namespace MoneyFox.Core.Commands.Payments.UpdatePayment
 {
 
     using System;
@@ -116,10 +116,10 @@
                 }
                 else if (!request.IsRecurring && existingPayment.RecurringPayment != null)
                 {
-                    contextAdapter.Context.RecurringPayments.Remove(existingPayment.RecurringPayment!);
                     var linkedPayments = contextAdapter.Context.Payments.Where(x => x.IsRecurring)
                         .Where(x => x.RecurringPayment!.Id == existingPayment.RecurringPayment!.Id)
                         .ToList();
+                    contextAdapter.Context.RecurringPayments.Remove(existingPayment.RecurringPayment!);
 
                     linkedPayments.ForEach(x => x.RemoveRecurringPayment());
                 }


### PR DESCRIPTION
… payments and added a test to validate this operation.

Issue: #2011 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
An exception is thrown when existing payments are changed from recurring to non-recurring.

## What is the new behavior?
Changing existing payments from recurring to non-recurring no longer throws an exception and completes successfully.

## PR Checklist

Please check if your PR fulfills the following requirements:

<!-- If the code was not tested on all plattforms, please describe why. -->

- [x] Tested code on Windows
- [x] Tested code on Android
- [x] Tested code on iOS
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
