### PR TITLE
Enhancement to default to the open account, if applicable, when addin…

### DIFF
--- a/Src/MoneyFox.Win/MoneyFox.Win/Pages/Payments/AddPaymentPage.xaml.cs
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Pages/Payments/AddPaymentPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace MoneyFox.Win.Pages.Payments;
+namespace MoneyFox.Win.Pages.Payments;
 
 using Core.ApplicationCore.Domain.Aggregates.AccountAggregate;
 using Core.Resources;
@@ -19,8 +19,16 @@ public sealed partial class AddPaymentPage
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        var passedType = e.Parameter as PaymentType?;
-        var type = passedType == null ? PaymentType.Expense : passedType.Value;
+        PaymentType type = PaymentType.Expense;
+        if (e.Parameter is PaymentType)
+        {
+            type = (PaymentType)e.Parameter;
+        }
+        else if (e.Parameter is int)
+        {
+            ViewModel.DefaultChargedAccountID = (int)e.Parameter;
+        }
+
         ViewModel.PaymentType = type;
         ViewModel.InitializeCommand.Execute(null);
     }

--- a/Src/MoneyFox.Win/MoneyFox.Win/Pages/Payments/PaymentListPage.xaml.cs
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Pages/Payments/PaymentListPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace MoneyFox.Win.Pages.Payments;
+namespace MoneyFox.Win.Pages.Payments;
 
 using System.Globalization;
 using CommunityToolkit.WinUI.UI.Controls;
@@ -17,6 +17,8 @@ public sealed partial class PaymentListPage
     }
 
     public override bool ShowHeader => false;
+
+    public int AccountID => ViewModel.AccountId;
 
     private PaymentListViewModel ViewModel => (PaymentListViewModel)DataContext;
 

--- a/Src/MoneyFox.Win/MoneyFox.Win/Pages/ShellPage.xaml.cs
+++ b/Src/MoneyFox.Win/MoneyFox.Win/Pages/ShellPage.xaml.cs
@@ -27,7 +27,8 @@ public sealed partial class ShellPage : Page
 
     private void AddPaymentItemTapped(object sender, TappedRoutedEventArgs e)
     {
-        MainContentFrame.Navigate(typeof(AddPaymentPage));
+        var isCurrentPagePaymentList = MainContentFrame.Content is PaymentListPage;
+        MainContentFrame.Navigate(typeof(AddPaymentPage), isCurrentPagePaymentList ? ((PaymentListPage)MainContentFrame.Content).AccountID : null);
     }
 
     private void MenuNav_BackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)

--- a/Src/MoneyFox.Win/MoneyFox.Win/ViewModels/Payments/AddPaymentViewModel.cs
+++ b/Src/MoneyFox.Win/MoneyFox.Win/ViewModels/Payments/AddPaymentViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace MoneyFox.Win.ViewModels.Payments;
+namespace MoneyFox.Win.ViewModels.Payments;
 
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,6 +21,8 @@ internal sealed class AddPaymentViewModel : ModifyPaymentViewModel
     private readonly IMapper mapper;
     private readonly IMediator mediator;
 
+    private int? defaultChargedAccountID = null;
+
     public AddPaymentViewModel(IMediator mediator, IMapper mapper, IDialogService dialogService, INavigationService navigationService) : base(
         mediator: mediator,
         mapper: mapper,
@@ -34,6 +36,8 @@ internal sealed class AddPaymentViewModel : ModifyPaymentViewModel
 
     public PaymentType PaymentType { get; set; }
 
+    public int? DefaultChargedAccountID { set => defaultChargedAccountID = value; }
+
     public RelayCommand InitializeCommand => new(async () => await InitializeAsync());
 
     protected override async Task InitializeAsync()
@@ -42,7 +46,7 @@ internal sealed class AddPaymentViewModel : ModifyPaymentViewModel
         AmountString = HelperFunctions.FormatLargeNumbers(SelectedPayment.Amount);
         SelectedPayment.Type = PaymentType;
         await base.InitializeAsync();
-        SelectedPayment.ChargedAccount = ChargedAccounts.FirstOrDefault();
+        SelectedPayment.ChargedAccount = defaultChargedAccountID.HasValue ? ChargedAccounts.FirstOrDefault(n => n.Id == defaultChargedAccountID.Value) : ChargedAccounts.FirstOrDefault();
         if (SelectedPayment.IsTransfer)
         {
             SelectedItemChangedCommand.Execute(null);

--- a/Src/MoneyFox/ViewModels/Payments/AddPaymentViewModel.cs
+++ b/Src/MoneyFox/ViewModels/Payments/AddPaymentViewModel.cs
@@ -27,10 +27,10 @@ namespace MoneyFox.ViewModels.Payments
             this.mapper = mapper;
         }
 
-        public new async Task InitializeAsync()
+        public async Task InitializeAsync(int? defaultChargedAccountID = null)
         {
             await base.InitializeAsync();
-            SelectedPayment.ChargedAccount = ChargedAccounts.FirstOrDefault();
+            SelectedPayment.ChargedAccount = defaultChargedAccountID.HasValue ? ChargedAccounts.FirstOrDefault(n => n.Id == defaultChargedAccountID.Value) : ChargedAccounts.FirstOrDefault();
         }
 
         protected override async Task SavePaymentAsync()

--- a/Src/MoneyFox/ViewModels/Payments/PaymentListViewModel.cs
+++ b/Src/MoneyFox/ViewModels/Payments/PaymentListViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace MoneyFox.ViewModels.Payments
+namespace MoneyFox.ViewModels.Payments
 {
 
     using System.Collections.Generic;
@@ -81,7 +81,10 @@
                 PaymentRecurrence.Yearly
             };
 
-        public AsyncRelayCommand GoToAddPaymentCommand => new AsyncRelayCommand(async () => await Shell.Current.GoToModalAsync(Routes.AddPaymentRoute));
+        public AsyncRelayCommand GoToAddPaymentCommand
+            => new AsyncRelayCommand(
+                async () => await Shell.Current.Navigation.PushModalAsync(
+                    new NavigationPage(new AddPaymentPage() { DefaultChargedAccountID = SelectedAccount.Id }) { BarBackgroundColor = Color.Transparent }));
 
         public AsyncRelayCommand<PaymentViewModel> GoToEditPaymentCommand
             => new AsyncRelayCommand<PaymentViewModel>(

--- a/Src/MoneyFox/Views/Payments/AddPaymentPage.xaml.cs
+++ b/Src/MoneyFox/Views/Payments/AddPaymentPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace MoneyFox.Views.Payments
+namespace MoneyFox.Views.Payments
 {
 
     using Core.Resources;
@@ -7,6 +7,14 @@
 
     public partial class AddPaymentPage
     {
+        private int? defaultChargedAccountID;
+
+        public int? DefaultChargedAccountID
+        {
+            // Change to init setter when the project is upgraded to C# 9.
+            set => defaultChargedAccountID = value;
+        }
+
         public AddPaymentPage()
         {
             InitializeComponent();
@@ -35,7 +43,7 @@
 
         protected override async void OnAppearing()
         {
-            await ViewModel.InitializeAsync();
+            await ViewModel.InitializeAsync(defaultChargedAccountID);
         }
     }
 


### PR DESCRIPTION
…g new payment transactions.

Issue: #2302

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
The target account is always set to the first account in the list when new payment transactions are added.


## What is the new behavior?
If the user has the payment list form open, the target account will be set to the currently open account when a new payment transaction is added. If any other form is open, the target account will be set to the first account in the list when new payment transactions are added (same as current behavior).


## PR Checklist

Please check if your PR fulfills the following requirements:

<!-- If the code was not tested on all plattforms, please describe why. -->

- [x] Tested code on Windows
- [x] Tested code on Android
- [x] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
