### PR TITLE
Add payment view does not extend on ios

### DIFF
--- a/Src/MoneyFox.Ui/Views/Accounts/ModifyAccountContentView.xaml
+++ b/Src/MoneyFox.Ui/Views/Accounts/ModifyAccountContentView.xaml
@@ -9,41 +9,39 @@
     x:Class="MoneyFox.Ui.Views.Accounts.ModifyAccountContentView"
     x:DataType="account:EditAccountViewModel">
 
-    <ContentView.Content>
-        <VerticalStackLayout Spacing="12">
+    <VerticalStackLayout Spacing="12">
 
-            <controls:TextEntry
-                TextFieldTitle="{x:Static resources:Strings.AccountNameLabel}"
-                EntryPlaceholder="{x:Static resources:Strings.AccountNameLabel}"
-                EntryText="{Binding SelectedAccountVm.Name}" />
+        <controls:TextEntry
+            TextFieldTitle="{x:Static resources:Strings.AccountNameLabel}"
+            EntryPlaceholder="{x:Static resources:Strings.AccountNameLabel}"
+            EntryText="{Binding SelectedAccountVm.Name}" />
 
-            <controls:AmountEntry
-                AmountFieldTitle="{x:Static resources:Strings.CurrentBalanceLabel}"
-                EntryPlaceholder="{x:Static resources:Strings.CurrentBalanceLabel}"
-                Amount="{Binding SelectedAccountVm.CurrentBalance}"
-                IsReadOnly="{Binding IsEdit}" />
+        <controls:AmountEntry
+            AmountFieldTitle="{x:Static resources:Strings.CurrentBalanceLabel}"
+            EntryPlaceholder="{x:Static resources:Strings.CurrentBalanceLabel}"
+            Amount="{Binding SelectedAccountVm.CurrentBalance}"
+            IsReadOnly="{Binding IsEdit}" />
 
-            <controls:TextEntry
-                TextFieldTitle="{x:Static resources:Strings.NoteLabel}"
-                EntryPlaceholder="{x:Static resources:Strings.NoteLabel}"
-                EntryText="{Binding SelectedAccountVm.Note}" />
+        <controls:TextEntry
+            TextFieldTitle="{x:Static resources:Strings.NoteLabel}"
+            EntryPlaceholder="{x:Static resources:Strings.NoteLabel}"
+            EntryText="{Binding SelectedAccountVm.Note}" />
 
-            <Grid Margin="0,5,0,0" HorizontalOptions="FillAndExpand">
+        <Grid Margin="0,5,0,0" HorizontalOptions="FillAndExpand">
 
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
 
-                <Label Grid.Column="0"
-                       Text="{x:Static resources:Strings.IsExcludedLabel}"
-                       VerticalOptions="Center" />
-                <Switch
-                    Grid.Column="1"
-                    HorizontalOptions="End"
-                    VerticalOptions="Center"
-                    IsToggled="{Binding SelectedAccountVm.IsExcluded}" />
-            </Grid>
-        </VerticalStackLayout>
-    </ContentView.Content>
+            <Label Grid.Column="0"
+                    Text="{x:Static resources:Strings.IsExcludedLabel}"
+                    VerticalOptions="Center" />
+            <Switch
+                Grid.Column="1"
+                HorizontalOptions="End"
+                VerticalOptions="Center"
+                IsToggled="{Binding SelectedAccountVm.IsExcluded}" />
+        </Grid>
+    </VerticalStackLayout>
 </ContentView>

--- a/Src/MoneyFox.Ui/Views/Categories/AddCategoryPage.xaml
+++ b/Src/MoneyFox.Ui/Views/Categories/AddCategoryPage.xaml
@@ -8,11 +8,9 @@
     Title="{x:Static resources:Strings.AddCategoryTitle}"
     x:Class="MoneyFox.Ui.Views.Categories.AddCategoryPage">
 
-    <ContentPage.Content>
-        <ScrollView Padding="15,0,15,0">
-            <StackLayout>
-                <categories:ModifyCategoryContentView />
-            </StackLayout>
-        </ScrollView>
-    </ContentPage.Content>
+    <ScrollView Padding="15,0,15,0">
+        <StackLayout>
+            <categories:ModifyCategoryContentView />
+        </StackLayout>
+    </ScrollView>
 </ContentPage>

--- a/Src/MoneyFox.Ui/Views/Categories/ModifyCategoryContentView.xaml
+++ b/Src/MoneyFox.Ui/Views/Categories/ModifyCategoryContentView.xaml
@@ -7,27 +7,25 @@
     xmlns:resources="clr-namespace:MoneyFox.Core.Resources;assembly=MoneyFox.Core"
     xmlns:controls="clr-namespace:MoneyFox.Ui.Controls">
 
-    <ContentView.Content>
-        <VerticalStackLayout Spacing="6">
-            <controls:TextEntry TextFieldTitle="{x:Static resources:Strings.CategoryNameLabel}"
-                                EntryPlaceholder="{x:Static resources:Strings.CategoryNameLabel}"
-                                EntryText="{Binding SelectedCategory.Name}" />
+    <VerticalStackLayout Spacing="6">
+        <controls:TextEntry TextFieldTitle="{x:Static resources:Strings.CategoryNameLabel}"
+                            EntryPlaceholder="{x:Static resources:Strings.CategoryNameLabel}"
+                            EntryText="{Binding SelectedCategory.Name}" />
 
-            <controls:TextEntry TextFieldTitle="{x:Static resources:Strings.NoteLabel}"
-                                EntryPlaceholder="{x:Static resources:Strings.NoteLabel}"
-                                EntryText="{Binding SelectedCategory.Note}" />
+        <controls:TextEntry TextFieldTitle="{x:Static resources:Strings.NoteLabel}"
+                            EntryPlaceholder="{x:Static resources:Strings.NoteLabel}"
+                            EntryText="{Binding SelectedCategory.Note}" />
 
-            <Grid ColumnDefinitions="*, Auto">
-                <Label
-                    Grid.Column="0"
-                    Text="{x:Static resources:Strings.RequireNoteCheckbox}"
-                    VerticalOptions="Center" />
+        <Grid ColumnDefinitions="*, Auto">
+            <Label
+                Grid.Column="0"
+                Text="{x:Static resources:Strings.RequireNoteCheckbox}"
+                VerticalOptions="Center" />
 
-                <CheckBox
-                    Grid.Column="1"
-                    IsChecked="{Binding SelectedCategory.RequireNote}"
-                    VerticalOptions="Center" />
-            </Grid>
-        </VerticalStackLayout>
-    </ContentView.Content>
+            <CheckBox
+                Grid.Column="1"
+                IsChecked="{Binding SelectedCategory.RequireNote}"
+                VerticalOptions="Center" />
+        </Grid>
+    </VerticalStackLayout>
 </ContentView>

--- a/Src/MoneyFox.Ui/Views/Payments/AddPaymentPage.xaml
+++ b/Src/MoneyFox.Ui/Views/Payments/AddPaymentPage.xaml
@@ -10,12 +10,10 @@
     x:DataType="paymentsVm:AddPaymentViewModel"
     x:Class="MoneyFox.Ui.Views.Payments.AddPaymentPage">
 
-    <ContentPage.Content>
-        <ScrollView Padding="15,0,15,0">
-            <StackLayout Spacing="6">
-                <payments:ModifyPaymentContentView />
-                <Button Text="{x:Static resources:Strings.SaveLabel}" Command="{Binding SaveCommand}" />
-            </StackLayout>
-        </ScrollView>
-    </ContentPage.Content>
+    <ScrollView Padding="15,0,15,0">
+        <VerticalStackLayout Spacing="6">
+            <payments:ModifyPaymentContentView />
+            <Button Text="{x:Static resources:Strings.SaveLabel}" Command="{Binding SaveCommand}" />
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentPage>

--- a/Src/MoneyFox.Ui/Views/Payments/EditPaymentPage.xaml
+++ b/Src/MoneyFox.Ui/Views/Payments/EditPaymentPage.xaml
@@ -9,26 +9,24 @@
     Title="{x:Static resources:Strings.EditPaymentTitle}"
     x:Class="MoneyFox.Ui.Views.Payments.EditPaymentPage">
 
-    <ContentPage.Content>
-        <ScrollView>
-            <StackLayout Padding="15,0,15,0">
-                <payments:ModifyPaymentContentView />
+    <ScrollView>
+        <VerticalStackLayout Padding="15,0,15,0">
+            <payments:ModifyPaymentContentView />
 
-                <Label Style="{StaticResource TextBodySecondary}"
-                       Text="{Binding SelectedPayment.Created, StringFormat={extensions:Translate CreationDateTemplateLabel}}" />
+            <Label Style="{StaticResource TextBodySecondary}"
+               Text="{Binding SelectedPayment.Created, StringFormat={extensions:Translate CreationDateTemplateLabel}}" />
 
-                <Label Style="{StaticResource TextBodySecondary}"
-                       Text="{Binding SelectedPayment.LastModified, StringFormat={extensions:Translate ModificationDateTemplateLabel}}" />
+            <Label Style="{StaticResource TextBodySecondary}"
+               Text="{Binding SelectedPayment.LastModified, StringFormat={extensions:Translate ModificationDateTemplateLabel}}" />
 
-                <Button Text="{x:Static resources:Strings.SaveLabel}" Command="{Binding SaveCommand}" />
+            <Button Text="{x:Static resources:Strings.SaveLabel}" Command="{Binding SaveCommand}" />
 
-                <Button x:Name="DeletePaymentButton"
-                        Style="{StaticResource WarningButton}"
-                        Margin="0,12,0,12"
-                        Command="{Binding DeleteCommand}"
-                        CommandParameter="{Binding SelectedPayment}"
-                        Text="{x:Static resources:Strings.DeleteLabel}" />
-            </StackLayout>
-        </ScrollView>
-    </ContentPage.Content>
+            <Button x:Name="DeletePaymentButton"
+                Style="{StaticResource WarningButton}"
+                Margin="0,12,0,12"
+                Command="{Binding DeleteCommand}"
+                CommandParameter="{Binding SelectedPayment}"
+                Text="{x:Static resources:Strings.DeleteLabel}" />
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentPage>

--- a/Src/MoneyFox.Ui/Views/Payments/ModifyPaymentContentView.xaml
+++ b/Src/MoneyFox.Ui/Views/Payments/ModifyPaymentContentView.xaml
@@ -74,7 +74,7 @@
                         IsToggled="{Binding SelectedPayment.IsRecurring}" />
             </Grid>
 
-            <StackLayout IsVisible="{Binding SelectedPayment.IsRecurring}"
+            <VerticalStackLayout IsVisible="{Binding SelectedPayment.IsRecurring}"
                          Spacing="6">
                 <Label Text="{x:Static resources:Strings.RecurrenceLabel}" />
                 <Picker ItemsSource="{Binding RecurrenceList}"
@@ -108,7 +108,7 @@
                                            DateField="{Binding SelectedPayment.RecurringPayment.EndDate}"
                                            IsVisible="{Binding SelectedPayment.RecurringPayment.IsEndless, Converter={StaticResource Inverter}}" />
 
-            </StackLayout>
+            </VerticalStackLayout>
         </VerticalStackLayout>
     </ScrollView>
 </ContentView>

--- a/Src/MoneyFox.Ui/Views/Payments/ModifyPaymentContentView.xaml
+++ b/Src/MoneyFox.Ui/Views/Payments/ModifyPaymentContentView.xaml
@@ -18,97 +18,95 @@
         </ResourceDictionary>
     </ContentView.Resources>
 
-    <ScrollView x:DataType="payments:ModifyPaymentViewModel" Padding="6,0,6,0">
-        <VerticalStackLayout Spacing="12">
+    <VerticalStackLayout Spacing="12" x:DataType="payments:ModifyPaymentViewModel">
 
-            <controls:PaymentTypePicker PickerTitle="{x:Static resources:Strings.PaymentTypeLabel}"
-                                        PaymentTypeSource="{Binding PaymentTypeList}"
-                                        SelectedType="{Binding SelectedPayment.Type}" />
+        <controls:PaymentTypePicker PickerTitle="{x:Static resources:Strings.PaymentTypeLabel}"
+                                    PaymentTypeSource="{Binding PaymentTypeList}"
+                                    SelectedType="{Binding SelectedPayment.Type}" />
 
-            <controls:AccountPicker PickerTitle="{Binding AccountHeader, Mode=OneWay}"
-                                    AccountsSource="{Binding ChargedAccounts}"
-                                    SelectedAccount="{Binding SelectedPayment.ChargedAccount}" />
+        <controls:AccountPicker PickerTitle="{Binding AccountHeader, Mode=OneWay}"
+                                AccountsSource="{Binding ChargedAccounts}"
+                                SelectedAccount="{Binding SelectedPayment.ChargedAccount}" />
 
-            <controls:AccountPicker PickerTitle="{x:Static resources:Strings.TargetAccountLabel}"
-                                    AccountsSource="{Binding TargetAccounts}"
-                                    SelectedAccount="{Binding SelectedPayment.TargetAccount}"
-                                    IsVisible="{Binding SelectedPayment.IsTransfer}" />
+        <controls:AccountPicker PickerTitle="{x:Static resources:Strings.TargetAccountLabel}"
+                                AccountsSource="{Binding TargetAccounts}"
+                                SelectedAccount="{Binding SelectedPayment.TargetAccount}"
+                                IsVisible="{Binding SelectedPayment.IsTransfer}" />
 
-            <controls:AmountEntry
-                AmountFieldTitle="{x:Static resources:Strings.AmountLabel}"
-                Amount="{Binding SelectedPayment.Amount}"
-                EntryPlaceholder="{x:Static resources:Strings.AmountLabel}" />
+        <controls:AmountEntry
+            AmountFieldTitle="{x:Static resources:Strings.AmountLabel}"
+            Amount="{Binding SelectedPayment.Amount}"
+            EntryPlaceholder="{x:Static resources:Strings.AmountLabel}" />
 
-            <Label Text="{x:Static resources:Strings.CategoryLabel}" />
+        <Label Text="{x:Static resources:Strings.CategoryLabel}" />
 
-            <Grid ColumnDefinitions="70*, 6, 40">
-                <Button Grid.Column="0"
-                        Text="{Binding SelectedPayment.Category, Converter={StaticResource NoCategorySelectedConverter}}"
-                        Command="{Binding GoToSelectCategoryDialogCommand}" />
+        <Grid ColumnDefinitions="70*, 6, 40">
+            <Button Grid.Column="0"
+                    Text="{Binding SelectedPayment.Category, Converter={StaticResource NoCategorySelectedConverter}}"
+                    Command="{Binding GoToSelectCategoryDialogCommand}" />
 
-                <ImageButton Grid.Column="2"
-                             Command="{Binding ResetCategoryCommand}">
-                    <ImageButton.Source>
-                        <FontImageSource FontFamily="MaterialIcons"
-                                         Glyph="{x:Static views:IconFont.Close}"
-                                         Color="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Gray900}}" />
-                    </ImageButton.Source>
-                </ImageButton>
-            </Grid>
+            <ImageButton Grid.Column="2"
+                            Command="{Binding ResetCategoryCommand}">
+                <ImageButton.Source>
+                    <FontImageSource FontFamily="MaterialIcons"
+                                        Glyph="{x:Static views:IconFont.Close}"
+                                        Color="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Gray900}}" />
+                </ImageButton.Source>
+            </ImageButton>
+        </Grid>
 
-            <controls:CustomDatePicker DatePickerTitle="{x:Static resources:Strings.DateLabel}"
-                                       DateField="{Binding SelectedPayment.Date}" />
+        <controls:CustomDatePicker DatePickerTitle="{x:Static resources:Strings.DateLabel}"
+                                    DateField="{Binding SelectedPayment.Date}" />
 
-            <controls:TextEntry
-                TextFieldTitle="{x:Static resources:Strings.NoteLabel}"
-                EntryPlaceholder="{x:Static resources:Strings.NoteLabel}"
-                EntryText="{Binding SelectedPayment.Note}" />
+        <controls:TextEntry
+            TextFieldTitle="{x:Static resources:Strings.NoteLabel}"
+            EntryPlaceholder="{x:Static resources:Strings.NoteLabel}"
+            EntryText="{Binding SelectedPayment.Note}" />
 
-            <Grid HorizontalOptions="FillAndExpand" ColumnDefinitions="*, Auto">
+        <Grid HorizontalOptions="FillAndExpand" ColumnDefinitions="*, Auto">
+            <Label Grid.Column="0"
+                    VerticalOptions="Center"
+                    Text="{x:Static resources:Strings.RecurringLabel}" />
+
+            <Switch Grid.Column="1"
+                    HorizontalOptions="End"
+                    IsToggled="{Binding SelectedPayment.IsRecurring}" />
+        </Grid>
+
+        <VerticalStackLayout IsVisible="{Binding SelectedPayment.IsRecurring}"
+                        Spacing="6">
+            <Label Text="{x:Static resources:Strings.RecurrenceLabel}" />
+            <Picker ItemsSource="{Binding RecurrenceList}"
+                    SelectedItem="{Binding SelectedPayment.RecurringPayment.Recurrence}" />
+
+            <Grid HorizontalOptions="FillAndExpand"
+                    ColumnDefinitions="70*, 15*"
+                    IsVisible="{Binding SelectedPayment.RecurringPayment.AllowLastDayOfMonth}">
+
                 <Label Grid.Column="0"
-                       VerticalOptions="Center"
-                       Text="{x:Static resources:Strings.RecurringLabel}" />
+                        VerticalOptions="Center"
+                        Text="{x:Static resources:Strings.LastDayOfMonthLabel}" />
 
                 <Switch Grid.Column="1"
                         HorizontalOptions="End"
-                        IsToggled="{Binding SelectedPayment.IsRecurring}" />
+                        IsToggled="{Binding SelectedPayment.RecurringPayment.IsLastDayOfMonth}" />
             </Grid>
 
-            <VerticalStackLayout IsVisible="{Binding SelectedPayment.IsRecurring}"
-                         Spacing="6">
-                <Label Text="{x:Static resources:Strings.RecurrenceLabel}" />
-                <Picker ItemsSource="{Binding RecurrenceList}"
-                        SelectedItem="{Binding SelectedPayment.RecurringPayment.Recurrence}" />
+            <Grid HorizontalOptions="FillAndExpand" ColumnDefinitions="*, Auto">
 
-                <Grid HorizontalOptions="FillAndExpand"
-                      ColumnDefinitions="70*, 15*"
-                      IsVisible="{Binding SelectedPayment.RecurringPayment.AllowLastDayOfMonth}">
+                <Label Grid.Column="0"
+                        VerticalOptions="Center"
+                        Text="{x:Static resources:Strings.EndlessLabel}" />
 
-                    <Label Grid.Column="0"
-                           VerticalOptions="Center"
-                           Text="{x:Static resources:Strings.LastDayOfMonthLabel}" />
+                <Switch Grid.Column="1"
+                        HorizontalOptions="Start"
+                        IsToggled="{Binding SelectedPayment.RecurringPayment.IsEndless}" />
+            </Grid>
 
-                    <Switch Grid.Column="1"
-                            HorizontalOptions="End"
-                            IsToggled="{Binding SelectedPayment.RecurringPayment.IsLastDayOfMonth}" />
-                </Grid>
+            <controls:CustomDatePicker DatePickerTitle="{x:Static resources:Strings.EnddateLabel}"
+                                        DateField="{Binding SelectedPayment.RecurringPayment.EndDate}"
+                                        IsVisible="{Binding SelectedPayment.RecurringPayment.IsEndless, Converter={StaticResource Inverter}}" />
 
-                <Grid HorizontalOptions="FillAndExpand" ColumnDefinitions="*, Auto">
-
-                    <Label Grid.Column="0"
-                           VerticalOptions="Center"
-                           Text="{x:Static resources:Strings.EndlessLabel}" />
-
-                    <Switch Grid.Column="1"
-                            HorizontalOptions="Start"
-                            IsToggled="{Binding SelectedPayment.RecurringPayment.IsEndless}" />
-                </Grid>
-
-                <controls:CustomDatePicker DatePickerTitle="{x:Static resources:Strings.EnddateLabel}"
-                                           DateField="{Binding SelectedPayment.RecurringPayment.EndDate}"
-                                           IsVisible="{Binding SelectedPayment.RecurringPayment.IsEndless, Converter={StaticResource Inverter}}" />
-
-            </VerticalStackLayout>
         </VerticalStackLayout>
-    </ScrollView>
+    </VerticalStackLayout>
 </ContentView>


### PR DESCRIPTION
Issue: -

Fixes that the add and edit payment view does not extend when for example Recurring is activated.

