### PR TITLE
2870 default currency reverts to chf when setting is opened

### DIFF
--- a/Src/MoneyFox.Ui.Tests/Views/Settings/SettingsViewModelTests.cs
+++ b/Src/MoneyFox.Ui.Tests/Views/Settings/SettingsViewModelTests.cs
@@ -1,5 +1,6 @@
 namespace MoneyFox.Ui.Tests.Views.Settings;
 
+using System.Globalization;
 using Core.Common.Settings;
 using Domain;
 using FluentAssertions;
@@ -7,33 +8,68 @@ using NSubstitute;
 using Ui.Views.Settings;
 using Xunit;
 
-public class SettingsViewModelTests
+public static class SettingsViewModelTests
 {
-    [Fact]
-    public void CollectionNotNullAfterCreation()
+    public sealed class Constructor
     {
-        // Arrange
-        var settingsFacade = Substitute.For<ISettingsFacade>();
+        [Fact]
+        public void CollectionNotNullAfterCreation()
+        {
+            // Arrange
+            var settingsFacade = Substitute.For<ISettingsFacade>();
 
-        // Act
-        var viewModel = new SettingsViewModel(settingsFacade: settingsFacade);
+            // Act
+            var viewModel = new SettingsViewModel(settingsFacade: settingsFacade);
 
-        // Assert
-        viewModel.AvailableCurrencies.Should().NotBeNull();
+            // Assert
+            viewModel.AvailableCurrencies.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void SetCurrencyFromSettings()
+        {
+            // Arrange
+            var settingsFacade = Substitute.For<ISettingsFacade>();
+            settingsFacade.DefaultCurrency.Returns("USD");
+
+            // Act
+            var viewModel = new SettingsViewModel(settingsFacade: settingsFacade);
+
+            // Assert
+            viewModel.AvailableCurrencies.Should().NotBeNull();
+            viewModel.SelectedCurrency.AlphaIsoCode.Should().Be("USD");
+        }
+
+        [Fact]
+        public void SetCurrencyFromRegion_WhenSettingNotSetYet()
+        {
+            // Arrange
+            var settingsFacade = Substitute.For<ISettingsFacade>();
+
+            // Act
+            var viewModel = new SettingsViewModel(settingsFacade: settingsFacade);
+
+            // Assert
+            viewModel.AvailableCurrencies.Should().NotBeNull();
+            viewModel.SelectedCurrency.AlphaIsoCode.Should().Be(RegionInfo.CurrentRegion.ISOCurrencySymbol);
+        }
     }
 
-    [Fact]
-    public void UpdateSettingsOnSet()
+    public sealed class CurrencySelected
     {
-        // Arrange
-        var settingsFacade = Substitute.For<ISettingsFacade>();
-        var viewModel = new SettingsViewModel(settingsFacade: settingsFacade);
+        [Fact]
+        public void UpdateSettingsOnSet()
+        {
+            // Arrange
+            var settingsFacade = Substitute.For<ISettingsFacade>();
+            var viewModel = new SettingsViewModel(settingsFacade: settingsFacade);
 
-        // Act
-        var newCurrency = new CurrencyViewModel(Currencies.CHF.AlphaIsoCode);
-        viewModel.SelectedCurrency = newCurrency;
+            // Act
+            var newCurrency = new CurrencyViewModel(Currencies.CHF.AlphaIsoCode);
+            viewModel.SelectedCurrency = newCurrency;
 
-        // Assert
-        settingsFacade.DefaultCurrency.Should().Be(newCurrency.AlphaIsoCode);
+            // Assert
+            settingsFacade.DefaultCurrency.Should().Be(newCurrency.AlphaIsoCode);
+        }
     }
 }

--- a/Src/MoneyFox.Ui/Views/Settings/SettingsViewModel.cs
+++ b/Src/MoneyFox.Ui/Views/Settings/SettingsViewModel.cs
@@ -15,7 +15,7 @@ internal sealed class SettingsViewModel : BasePageViewModel
         this.settingsFacade = settingsFacade;
         AvailableCurrencies = Currencies.GetAll().Select(c => new CurrencyViewModel(c.AlphaIsoCode)).OrderBy(c => c.AlphaIsoCode).ToList();
         var currencyToLoad = string.IsNullOrEmpty(settingsFacade.DefaultCurrency) ? RegionInfo.CurrentRegion.ISOCurrencySymbol : settingsFacade.DefaultCurrency;
-        SelectedCurrency = AvailableCurrencies.FirstOrDefault(c => c.AlphaIsoCode == currencyToLoad) ?? AvailableCurrencies.First();
+        SelectedCurrency = AvailableCurrencies.FirstOrDefault(c => c.AlphaIsoCode == currencyToLoad) ?? AvailableCurrencies[0];
     }
 
     public CurrencyViewModel SelectedCurrency

--- a/Src/MoneyFox.Ui/Views/Settings/SettingsViewModel.cs
+++ b/Src/MoneyFox.Ui/Views/Settings/SettingsViewModel.cs
@@ -14,7 +14,8 @@ internal sealed class SettingsViewModel : BasePageViewModel
     {
         this.settingsFacade = settingsFacade;
         AvailableCurrencies = Currencies.GetAll().Select(c => new CurrencyViewModel(c.AlphaIsoCode)).OrderBy(c => c.AlphaIsoCode).ToList();
-        SelectedCurrency = AvailableCurrencies.FirstOrDefault(c => c.AlphaIsoCode == RegionInfo.CurrentRegion.ISOCurrencySymbol) ?? AvailableCurrencies.First();
+        var currencyToLoad = string.IsNullOrEmpty(settingsFacade.DefaultCurrency) ? RegionInfo.CurrentRegion.ISOCurrencySymbol : settingsFacade.DefaultCurrency;
+        SelectedCurrency = AvailableCurrencies.FirstOrDefault(c => c.AlphaIsoCode == currencyToLoad) ?? AvailableCurrencies.First();
     }
 
     public CurrencyViewModel SelectedCurrency


### PR DESCRIPTION
Issue: fix #2870

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
View is always initialized with the currency from the current region.

## What is the new behavior?
The region is used as fallback if the default currency wasn't set yet.

## PR Checklist

Please check if your PR fulfills the following requirements:

<!-- If the code was not tested on all plattforms, please describe why. -->

- [x] Tested code on Windows
- [ ] Tested code on Android
- [ ] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
