### PR TITLE
Make it mandatory that you have at least one account after setup wizard

### DIFF
--- a/Src/MoneyFox.Ui.Tests/Views/SetupAssistant/SetupAccountViewModelTests.cs
+++ b/Src/MoneyFox.Ui.Tests/Views/SetupAssistant/SetupAccountViewModelTests.cs
@@ -6,6 +6,7 @@ using MoneyFox.Core.Queries;
 using Domain.Aggregates.AccountAggregate;
 
 using Ui.Views.Setup;
+using MoneyFox.Domain;
 
 public class SetupAccountViewModelTests
 {
@@ -23,7 +24,7 @@ public class SetupAccountViewModelTests
         await vm.MadeAccount();
         vm.HasAnyAccount.Should().BeFalse();
 
-        var accounts = new List<Account> { new("TestAccount") };
+        var accounts = new List<GetAccountsQuery.AccountData> { new(Id: 1, Name: "TestAccount", CurrentBalance: Money.Zero(Currencies.USD), IsExcluded: false) };
         mediator.Send(Arg.Any<GetAccountsQuery>()).Returns(accounts);
 
         await vm.MadeAccount();

--- a/Src/MoneyFox.Ui.Tests/Views/SetupAssistant/SetupAccountViewModelTests.cs
+++ b/Src/MoneyFox.Ui.Tests/Views/SetupAssistant/SetupAccountViewModelTests.cs
@@ -1,0 +1,32 @@
+namespace MoneyFox.Ui.Tests.Views.SetupAssistant;
+
+using Common.Navigation;
+using MediatR;
+using MoneyFox.Core.Queries;
+using Domain.Aggregates.AccountAggregate;
+
+using Ui.Views.Setup;
+
+public class SetupAccountViewModelTests
+{
+    [Fact]
+    public async void HasAccount()
+    {
+        // Arrange
+        var navigationService = Substitute.For<INavigationService>();
+        var mediator = Substitute.For<IMediator>();
+
+        // Act
+        var vm = new SetupAccountsViewModel(navigationService, mediator);
+
+        // Assert
+        await vm.MadeAccount();
+        vm.HasAnyAccount.Should().BeFalse();
+
+        var accounts = new List<Account> { new("TestAccount") };
+        mediator.Send(Arg.Any<GetAccountsQuery>()).Returns(accounts);
+
+        await vm.MadeAccount();
+        vm.HasAnyAccount.Should().BeTrue();
+    }
+}

--- a/Src/MoneyFox.Ui.Tests/Views/SetupAssistant/SetupAccountViewModelTests.cs
+++ b/Src/MoneyFox.Ui.Tests/Views/SetupAssistant/SetupAccountViewModelTests.cs
@@ -4,7 +4,6 @@ using Common.Navigation;
 using MediatR;
 using MoneyFox.Core.Queries;
 using Domain.Aggregates.AccountAggregate;
-
 using Ui.Views.Setup;
 using MoneyFox.Domain;
 

--- a/Src/MoneyFox.Ui/Views/Setup/SetupAccountPage.xaml
+++ b/Src/MoneyFox.Ui/Views/Setup/SetupAccountPage.xaml
@@ -35,6 +35,7 @@
 
             <Button Grid.Column="2"
                     VerticalOptions="Center"
+                    x:Name="NextStepButton"
                     Text="{x:Static resources:Translations.NextLabel}"
                     Command="{Binding NextStepCommand}" />
         </Grid>

--- a/Src/MoneyFox.Ui/Views/Setup/SetupAccountPage.xaml.cs
+++ b/Src/MoneyFox.Ui/Views/Setup/SetupAccountPage.xaml.cs
@@ -8,4 +8,11 @@ public partial class SetupAccountPage : IBindablePage
     {
         InitializeComponent();
     }
+    private SetupAccountsViewModel ViewModel => (SetupAccountsViewModel)BindingContext;
+
+    protected override async void OnAppearing()
+    {
+        await ViewModel.MadeAccount();
+        NextStepButton.IsVisible = ViewModel.HasAnyAccount;
+    }
 }

--- a/Src/MoneyFox.Ui/Views/Setup/SetupAccountsViewModel.cs
+++ b/Src/MoneyFox.Ui/Views/Setup/SetupAccountsViewModel.cs
@@ -3,12 +3,23 @@ namespace MoneyFox.Ui.Views.Setup;
 using Accounts.AccountModification;
 using Common.Navigation;
 using CommunityToolkit.Mvvm.Input;
+using MediatR;
+using MoneyFox.Core.Queries;
 
-public sealed class SetupAccountsViewModel(INavigationService navigationService) : NavigableViewModel
+public sealed class SetupAccountsViewModel(INavigationService navigationService, IMediator mediator) : NavigableViewModel
 {
     public AsyncRelayCommand GoToAddAccountCommand => new(() => navigationService.GoTo<AddAccountViewModel>());
 
     public AsyncRelayCommand NextStepCommand => new(() => navigationService.GoTo<SetupCategoryViewModel>());
 
     public AsyncRelayCommand BackCommand => new(() => navigationService.GoBack());
+
+    public async Task MadeAccount()
+    {
+        var accountVms = await mediator.Send(new GetAccountsQuery());
+
+        HasAnyAccount = accountVms.Any();
+    }
+
+    public bool HasAnyAccount { get; private set; }
 }


### PR DESCRIPTION
Issue: #
https://github.com/MoneyFox/MoneyFox/issues/3021

## PR Type
What kind of change does this PR introduce?
Feature


## What is the current behavior?
User could finish setup wizard without creating an account.


## What is the new behavior?
User now needs at least one account to finish setup wizard

## PR Checklist

Please check if your PR fulfills the following requirements:

<!-- If the code was not tested on all plattforms, please describe why. -->
Code was not tested on iOS because I do not own any iOS device.

- [x] Tested code on Windows
- [x] Tested code on Android
- [ ] Tested code on iOS
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes



## Other information
