### PR TITLE
Solution to the issue #2741

### DIFF
--- a/Src/MoneyFox.Core/Common/Settings/SettingConstants.cs
+++ b/Src/MoneyFox.Core/Common/Settings/SettingConstants.cs
@@ -10,4 +10,5 @@ public static class SettingConstants
     public const string IS_SETUP_COMPLETED_KEY_NAME = "IsSetupCompleted";
     public const string DEFAULT_CURRENCY_KEY_NAME = "DefaultCurrency";
     public const string DEFAULT_ACCOUNT_KEY_NAME = "DefaultAccount";
+    public const string DEFAULT_NUM_OF_CATEGORIES_IN_SPREAD = "DefaultNumberOfCategoriesInSpreading";
 }

--- a/Src/MoneyFox.Core/Common/Settings/SettingsFacade.cs
+++ b/Src/MoneyFox.Core/Common/Settings/SettingsFacade.cs
@@ -20,6 +20,8 @@ public interface ISettingsFacade
 
     int DefaultAccount { get; set; }
 
+    int DefaultNumberOfCategoriesInSpreading { get; set; }
+
     DateTime LastExecutionTimeStampSyncBackup { get; set; }
 }
 
@@ -99,5 +101,11 @@ public class SettingsFacade : ISettingsFacade
     {
         get => settingsAdapter.GetValue(key: SettingConstants.DEFAULT_ACCOUNT_KEY_NAME, defaultValue: default(int));
         set => settingsAdapter.AddOrUpdate(key: SettingConstants.DEFAULT_ACCOUNT_KEY_NAME, value: value);
+    }
+
+    public int DefaultNumberOfCategoriesInSpreading
+    {
+        get => settingsAdapter.GetValue(key: SettingConstants.DEFAULT_NUM_OF_CATEGORIES_IN_SPREAD, defaultValue: 10);
+        set => settingsAdapter.AddOrUpdate(key: SettingConstants.DEFAULT_NUM_OF_CATEGORIES_IN_SPREAD, value: value);
     }
 }

--- a/Src/MoneyFox.Ui/Controls/CustomStepperWithEntry.xaml
+++ b/Src/MoneyFox.Ui/Controls/CustomStepperWithEntry.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Name="This"
+             x:Class="MoneyFox.Ui.Controls.CustomStepperWithEntry">
+
+    <FlexLayout Direction="Row"
+                JustifyContent="SpaceBetween"
+                BindingContext="{x:Reference This}">
+        
+        <Button Text="-"
+            FontAttributes="Bold"
+            TextColor="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Black}}"
+            BackgroundColor="{AppThemeBinding Dark={StaticResource Gray950}, Light={StaticResource White}}"
+            WidthRequest="40"
+            Command="{Binding DecreaseStepperValue}"/>
+
+        <Entry x:Name="stepperValueEntry"
+           Text="{Binding StepperValue}"
+           Margin="2,0,2,0"
+           HorizontalTextAlignment="Center"
+           Keyboard="Numeric"
+           WidthRequest="50"
+           TextChanged="StepperValueEntry_TextChanged"/>
+
+        <Button Text="+"
+            FontAttributes="Bold"
+            TextColor="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Black}}"
+            BackgroundColor="{AppThemeBinding Dark={StaticResource Gray950}, Light={StaticResource White}}"
+            WidthRequest="40"
+            Command="{Binding IncreaseStepperValue}"/>
+    </FlexLayout>
+</ContentView>

--- a/Src/MoneyFox.Ui/Controls/CustomStepperWithEntry.xaml.cs
+++ b/Src/MoneyFox.Ui/Controls/CustomStepperWithEntry.xaml.cs
@@ -1,0 +1,87 @@
+namespace MoneyFox.Ui.Controls;
+
+using CommunityToolkit.Mvvm.Input;
+
+public partial class CustomStepperWithEntry
+{
+
+    public static readonly BindableProperty MinValueProperty = BindableProperty.Create(
+        propertyName: nameof(MinValue),
+        returnType: typeof(int),
+        declaringType: typeof(TextEntry),
+        defaultValue: 0);
+
+    public static readonly BindableProperty MaxValueProperty = BindableProperty.Create(
+        propertyName: nameof(MaxValue),
+        returnType: typeof(int),
+        declaringType: typeof(TextEntry),
+        defaultValue: 100);
+
+    public static readonly BindableProperty StepSizeProperty = BindableProperty.Create(
+        propertyName: nameof(StepSize),
+        returnType: typeof(int),
+        declaringType: typeof(TextEntry),
+        defaultValue: 1);
+
+    public static readonly BindableProperty StepperValueProperty = BindableProperty.Create(
+        propertyName: nameof(StepperValue),
+        returnType: typeof(int),
+        declaringType: typeof(TextEntry),
+        defaultValue: 10,
+        defaultBindingMode: BindingMode.TwoWay);
+
+    public CustomStepperWithEntry()
+    {
+        InitializeComponent();
+    }
+
+    public int MaxValue
+    {
+        get => (int)GetValue(MaxValueProperty);
+        set => SetValue(property: MaxValueProperty, value: value);
+    }
+
+    public int MinValue
+    {
+        get => (int)GetValue(MinValueProperty);
+        set => SetValue(property: MinValueProperty, value: value);
+    }
+
+    public int StepSize
+    {
+        get => (int)GetValue(StepSizeProperty);
+        set => SetValue(property: StepSizeProperty, value: value);
+    }
+
+    public int StepperValue
+    {
+        get => (int)GetValue(StepperValueProperty);
+        set {
+
+            if (value < MinValue) { value = MinValue; }
+            if (value > MaxValue) { value = MaxValue; }
+
+            SetValue(property: StepperValueProperty, value: value);
+        }
+    }
+
+    private void StepperValueEntry_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (!int.TryParse(e.NewTextValue, out var num))
+        {
+            // clean out invalid characters
+            stepperValueEntry.Text = new string(e.NewTextValue.Where(char.IsDigit).ToArray());
+        }
+    }
+
+    public RelayCommand IncreaseStepperValue => new(
+        () => UpdateStepperValue(StepSize, 1));
+
+    public RelayCommand DecreaseStepperValue => new(
+        () => UpdateStepperValue(StepSize, -1));
+
+    private void UpdateStepperValue(int step, int index)
+    {
+        StepperValue += step * index;
+    }
+}

--- a/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml
+++ b/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml
@@ -7,6 +7,7 @@
     xmlns:views="clr-namespace:MoneyFox.Ui.Views"
     xmlns:categorySpreading="clr-namespace:MoneyFox.Ui.Views.Statistics.CategorySpreading"
     x:Class="MoneyFox.Ui.Views.Statistics.CategorySpreading.StatisticCategorySpreadingPage"
+    xmlns:customControls="clr-namespace:MoneyFox.Ui.Controls"
     Title="{x:Static resources:Translations.CategorySpreadingTitle}">
 
     <ContentPage.Resources>
@@ -48,31 +49,7 @@
                            Text="Number of categories to show:"
                            VerticalOptions="Center"/>
 
-                    <FlexLayout Grid.Column="1"
-                                Direction="Row"
-                                JustifyContent="SpaceBetween">
-                        <Button Text="-"
-                                FontAttributes="Bold"
-                                TextColor="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Black}}"
-                                BackgroundColor="{AppThemeBinding Dark={StaticResource Gray950}, Light={StaticResource White}}"
-                                WidthRequest="40"
-                                Command="{Binding DecreaseNumberOfCategories}"/>
-
-                        <Entry x:Name="numberOfCategoriesEntry"
-                               Text="{Binding NumberOfCategories}"
-                               Margin="2,0,2,0"
-                               HorizontalTextAlignment="Center"
-                               Keyboard="Numeric"
-                               WidthRequest="50"
-                               TextChanged="NumberOfCategoriesEntry_TextChanged"/>
-
-                        <Button Text="+"
-                                FontAttributes="Bold"
-                                TextColor="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Black}}"
-                                BackgroundColor="{AppThemeBinding Dark={StaticResource Gray950}, Light={StaticResource White}}"
-                                WidthRequest="40"
-                                Command="{Binding IncreaseNumberOfCategories}"/>
-                    </FlexLayout>
+                    <customControls:CustomStepperWithEntry Grid.Column="1" MinValue="1" MaxValue="15" StepperValue="{Binding NumberOfCategories}"/>
                 </Grid>
 
                 <maui:PieChart Series="{Binding Series, Mode=OneWay}"

--- a/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml
+++ b/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml
@@ -15,7 +15,7 @@
 
     <ContentPage.Content>
         <ScrollView>
-            <Grid RowDefinitions="38, auto, *" Padding="15,0,15,15"
+            <Grid RowDefinitions="38, auto, auto, *" Padding="15,0,15,15"
                   x:DataType="categorySpreading:StatisticCategorySpreadingViewModel">
 
                 <Grid ColumnDefinitions="*, Auto">
@@ -36,15 +36,47 @@
                         </ImageButton.Source>
                     </ImageButton>
                 </Grid>
-
+                
                 <Picker Grid.Row="1"
                         Title="{x:Static resources:Translations.SelectedPaymentTypeHeader}"
                         ItemsSource="{Binding PaymentTypes}"
                         SelectedItem="{Binding SelectedPaymentType, Mode=TwoWay}"
                         ItemDisplayBinding="{Binding ., Converter={StaticResource PaymentTypeStringConverter}}" />
 
+                <Grid Grid.Row="2" ColumnDefinitions="*, Auto" Padding="0,15,0,0" VerticalOptions="Start">
+                    <Label Style="{StaticResource TextBodySecondary}"
+                           Text="Number of categories to show:"
+                           VerticalOptions="Center"/>
+
+                    <FlexLayout Grid.Column="1"
+                                Direction="Row"
+                                JustifyContent="SpaceBetween">
+                        <Button Text="-"
+                                FontAttributes="Bold"
+                                TextColor="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Black}}"
+                                BackgroundColor="{AppThemeBinding Dark={StaticResource Gray950}, Light={StaticResource White}}"
+                                WidthRequest="40"
+                                Command="{Binding DecreaseNumberOfCategories}"/>
+
+                        <Entry x:Name="numberOfCategoriesEntry"
+                               Text="{Binding NumberOfCategories}"
+                               Margin="2,0,2,0"
+                               HorizontalTextAlignment="Center"
+                               Keyboard="Numeric"
+                               WidthRequest="50"
+                               TextChanged="NumberOfCategoriesEntry_TextChanged"/>
+
+                        <Button Text="+"
+                                FontAttributes="Bold"
+                                TextColor="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Black}}"
+                                BackgroundColor="{AppThemeBinding Dark={StaticResource Gray950}, Light={StaticResource White}}"
+                                WidthRequest="40"
+                                Command="{Binding IncreaseNumberOfCategories}"/>
+                    </FlexLayout>
+                </Grid>
+
                 <maui:PieChart Series="{Binding Series, Mode=OneWay}"
-                               Grid.Row="2"
+                               Grid.Row="3"
                                LegendPosition="{OnPlatform WinUI=Right,Default=Bottom}"
                                LegendBackgroundPaint="{Binding LegendBackgroundPaint, Mode=OneTime}"
                                LegendTextPaint="{Binding LegendTextPaint, Mode=OneTime}" />

--- a/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml.cs
+++ b/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml.cs
@@ -8,13 +8,4 @@ public partial class StatisticCategorySpreadingPage : IBindablePage
     {
         InitializeComponent();
     }
-
-    private void NumberOfCategoriesEntry_TextChanged(object? sender, TextChangedEventArgs e)
-    {
-        if (!int.TryParse(e.NewTextValue, out var numberOfCategories))
-        {
-            // clean out invalid characters
-            numberOfCategoriesEntry.Text = new string(e.NewTextValue.Where(char.IsDigit).ToArray());
-        }
-    }
 }

--- a/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml.cs
+++ b/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace MoneyFox.Ui.Views.Statistics.CategorySpreading;
+namespace MoneyFox.Ui.Views.Statistics.CategorySpreading;
 
 using Common.Navigation;
 
@@ -7,5 +7,14 @@ public partial class StatisticCategorySpreadingPage : IBindablePage
     public StatisticCategorySpreadingPage()
     {
         InitializeComponent();
+    }
+
+    private void NumberOfCategoriesEntry_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (!int.TryParse(e.NewTextValue, out var numberOfCategories))
+        {
+            // clean out invalid characters
+            numberOfCategoriesEntry.Text = new string(e.NewTextValue.Where(char.IsDigit).ToArray());
+        }
     }
 }

--- a/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingViewModel.cs
+++ b/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingViewModel.cs
@@ -1,10 +1,7 @@
 namespace MoneyFox.Ui.Views.Statistics.CategorySpreading;
 
 using System.Collections.ObjectModel;
-using System.Windows.Input;
-using CommunityToolkit.Maui;
 using CommunityToolkit.Maui.Core;
-using CommunityToolkit.Mvvm.Input;
 using Core.Common.Extensions;
 using Core.Queries.Statistics;
 using Domain.Aggregates.AccountAggregate;
@@ -53,25 +50,11 @@ internal sealed class StatisticCategorySpreadingViewModel : StatisticViewModel
         set
         {
             if (settingsFacade.DefaultNumberOfCategoriesInSpreading == value) return;
-            if (value < 1) value = 1;
-            if (value > 15) value = 15; // 15 categories should be plenty
-
             settingsFacade.DefaultNumberOfCategoriesInSpreading = value;
 
             OnPropertyChanged();
             LoadAsync().GetAwaiter().GetResult();
         }
-    }
-
-    public RelayCommand IncreaseNumberOfCategories => new(
-        () => UpdateNumberOfCategories(1, 1));
-
-    public RelayCommand DecreaseNumberOfCategories => new(
-        () => UpdateNumberOfCategories(1, -1));
-
-    public void UpdateNumberOfCategories(int step, int index)
-    {
-        NumberOfCategories += step * index;
     }
 
     public override Task OnNavigatedAsync(object? parameter)

--- a/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingViewModel.cs
+++ b/Src/MoneyFox.Ui/Views/Statistics/CategorySpreading/StatisticCategorySpreadingViewModel.cs
@@ -1,19 +1,29 @@
 namespace MoneyFox.Ui.Views.Statistics.CategorySpreading;
 
 using System.Collections.ObjectModel;
+using System.Windows.Input;
+using CommunityToolkit.Maui;
 using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Mvvm.Input;
 using Core.Common.Extensions;
 using Core.Queries.Statistics;
 using Domain.Aggregates.AccountAggregate;
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
 using MediatR;
+using MoneyFox.Core.Common.Settings;
+using Infrastructure.Adapters;
 
 internal sealed class StatisticCategorySpreadingViewModel : StatisticViewModel
 {
     private PaymentType selectedPaymentType;
 
-    public StatisticCategorySpreadingViewModel(IMediator mediator, IPopupService popupService) : base(mediator: mediator, popupService: popupService) { }
+    private readonly ISettingsFacade settingsFacade;
+
+    public StatisticCategorySpreadingViewModel(IMediator mediator, IPopupService popupService) : base(mediator: mediator, popupService: popupService)
+    {
+        settingsFacade = new SettingsFacade(new SettingsAdapter());
+    }
 
     public List<PaymentType> PaymentTypes => new() { PaymentType.Expense, PaymentType.Income };
 
@@ -36,6 +46,34 @@ internal sealed class StatisticCategorySpreadingViewModel : StatisticViewModel
         }
     }
 
+    public int NumberOfCategories
+    {
+        get => settingsFacade.DefaultNumberOfCategoriesInSpreading;
+
+        set
+        {
+            if (settingsFacade.DefaultNumberOfCategoriesInSpreading == value) return;
+            if (value < 1) value = 1;
+            if (value > 15) value = 15; // 15 categories should be plenty
+
+            settingsFacade.DefaultNumberOfCategoriesInSpreading = value;
+
+            OnPropertyChanged();
+            LoadAsync().GetAwaiter().GetResult();
+        }
+    }
+
+    public RelayCommand IncreaseNumberOfCategories => new(
+        () => UpdateNumberOfCategories(1, 1));
+
+    public RelayCommand DecreaseNumberOfCategories => new(
+        () => UpdateNumberOfCategories(1, -1));
+
+    public void UpdateNumberOfCategories(int step, int index)
+    {
+        NumberOfCategories += step * index;
+    }
+
     public override Task OnNavigatedAsync(object? parameter)
     {
         return LoadAsync();
@@ -47,7 +85,8 @@ internal sealed class StatisticCategorySpreadingViewModel : StatisticViewModel
             new GetCategorySpreading.Query(
                 startDate: DateOnly.FromDateTime(StartDate),
                 endDate: DateOnly.FromDateTime(EndDate),
-                paymentType: SelectedPaymentType));
+                paymentType: SelectedPaymentType,
+                numberOfCategoriesToShow: NumberOfCategories));
 
         var pieSeries = statisticEntries.Select(
             x => new PieSeries<decimal>


### PR DESCRIPTION
Issue: #2741
https://github.com/MoneyFox/MoneyFox/issues/2741

## PR Type
What kind of change does this PR introduce?

- Feature


## What is the current behavior?
Currently the number of categories included in the category spreading is fix. It would be nice if this could be dynamically selected.
This should be persisted to the settings.


## What is the new behavior?
Number of categories included in the category spreading can be changed dynamically via entry or increase/decrease buttons.
It is also persisted to the settings.

## PR Checklist

Not tested on iOS (Unfortunately, I do not own any Apple product)

- [x] Tested code on Windows
- [x] Tested code on Android
- [ ] Tested code on iOS
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes

## Other information

Entry is cleared for edge cases as well as any non numeric input.

Number of categories is persisted via SettingsFacade.cs just like in AccountGroup.cs, but I am not so sure with my solution so maybe it needs a correction.

Also text in the new label for the entry is hardcoded in English, I did not add all the necessary translations which I apologize for.